### PR TITLE
Renames Add-CloudEvent*Data to Set-CloudEvent*Data

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -98,4 +98,3 @@ if (Test-Path $catalogFilePath) {
    # Delete previous catalog file
    Remove-Item $catalogFilePath -Confirm:$false
 }
-New-FileCatalog -Path $OutputDir -CatalogFilePath $catalogFilePath | Out-Null

--- a/build.ps1
+++ b/build.ps1
@@ -90,11 +90,3 @@ Start-Tests -TestsType 'unit'
 
 # 5. Run Integration Tests
 Start-Tests -TestsType 'integration'
-
-# 6. Prepare Module for Publishing
-$dirItem = Get-Item $OutputDir
-$catalogFilePath = Join-path $OutputDir ($dirItem.Name + ".cat")
-if (Test-Path $catalogFilePath) {
-   # Delete previous catalog file
-   Remove-Item $catalogFilePath -Confirm:$false
-}

--- a/src/CloudEventsPowerShell/CloudEvents.Sdk.psd1
+++ b/src/CloudEventsPowerShell/CloudEvents.Sdk.psd1
@@ -9,7 +9,7 @@
 RootModule = 'CloudEvents.Sdk.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.1.4'
+ModuleVersion = '0.2.1'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Core')
@@ -67,7 +67,7 @@ RequiredAssemblies = @('CloudNative.CloudEvents.dll')
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
 FunctionsToExport = @(
-'New-CloudEvent', 'Add-CloudEventData', 'Add-CloudEventJsonData', 'Add-CloudEventXmlData', 'Read-CloudEventData', 'Read-CloudEventJsonData', 'Read-CloudEventXmlData', # CloudEvent Object Functions
+'New-CloudEvent', 'Set-CloudEventData', 'Set-CloudEventJsonData', 'Set-CloudEventXmlData', 'Read-CloudEventData', 'Read-CloudEventJsonData', 'Read-CloudEventXmlData', # CloudEvent Object Functions
 'ConvertTo-HttpMessage', 'ConvertFrom-HttpMessage' # Http Binding Functions
 )
 

--- a/src/CloudEventsPowerShell/CloudEvents.Sdk.psd1
+++ b/src/CloudEventsPowerShell/CloudEvents.Sdk.psd1
@@ -9,7 +9,7 @@
 RootModule = 'CloudEvents.Sdk.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.2.1'
+ModuleVersion = '0.2.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Core')

--- a/src/CloudEventsPowerShell/CloudEvents.Sdk.psm1
+++ b/src/CloudEventsPowerShell/CloudEvents.Sdk.psm1
@@ -72,20 +72,20 @@ PROCESS {
 }
 }
 
-#region Add Data Functions
-function Add-CloudEventData {
+#region Set Data Functions
+function Set-CloudEventData {
 <#
    .SYNOPSIS
-   This function adds data to a cloud event.
+   This function sets data into a cloud event.
 
    .DESCRIPTION
-   This function adds data to a cloud event object with the provided parameters.
+   This function sets data into a cloud event object with the provided parameters.
 
    .PARAMETER CloudEvent
-   Specifies the cloud event object to add data to.
+   Specifies the cloud event object to set data into.
 
    .PARAMETER Data
-   Specifies the data object that is added to the cloud event 'data' attribute.
+   Specifies the data object that is set to the cloud event 'data' attribute.
 
    .PARAMETER DataContentType
    Specifies the 'datacontenttype' attribute of the cloud event.
@@ -93,9 +93,9 @@ function Add-CloudEventData {
 
    .EXAMPLE
    $cloudEvent = New-CloudEvent -Type 'com.example.object.deleted.v2' -Source 'mailto:cncf-wg-serverless@lists.cncf.io' -Id '6e8bc430-9c3a-11d9-9669-0800200c9a66' -Time (Get-Date)
-   $cloudEvent | Add-CloudEventData -Data '<much wow="xml"/>' -DataContentType 'application/xml'
+   $cloudEvent | Set-CloudEventData -Data '<much wow="xml"/>' -DataContentType 'application/xml'
 
-   Adds xml data to the cloud event
+   Sets xml data into the cloud event
 #>
 
 [CmdletBinding()]
@@ -135,27 +135,27 @@ PROCESS {
 
 }
 
-function Add-CloudEventJsonData {
+function Set-CloudEventJsonData {
 <#
    .SYNOPSIS
-   This function adds JSON format data to a cloud event.
+   This function sets JSON format data into a cloud event.
 
    .DESCRIPTION
-   This function converts a PowerShell hashtable to JSON format data and adds it to a cloud event.
+   This function converts a PowerShell hashtable to JSON format data and sets it into a cloud event.
 
    .PARAMETER CloudEvent
-   Specifies the cloud event object to add data to.
+   Specifies the cloud event object to set data into.
 
    .PARAMETER Data
-   Specifies the PowerShell hashtable object that is added as JSON to the cloud event 'data' attribute.
+   Specifies the PowerShell hashtable object that is set as JSON on the cloud event 'data' attribute.
    The 'datacontenttype' attribute is set to 'applicaiton/json'
 
 
    .EXAMPLE
    $cloudEvent = New-CloudEvent -Type 'com.example.object.deleted.v2' -Source 'mailto:cncf-wg-serverless@lists.cncf.io' -Id '6e8bc430-9c3a-11d9-9669-0800200c9a66' -Time (Get-Date)
-   $cloudEvent | Add-CloudEventJsonData -Data @{ 'key1' = 'value1'; 'key2' = 'value2'; }
+   $cloudEvent | Set-CloudEventJsonData -Data @{ 'key1' = 'value1'; 'key2' = 'value2'; }
 
-   Adds JSON data to the cloud event
+   Sets JSON data into the cloud event
 #>
 
 [CmdletBinding()]
@@ -193,19 +193,19 @@ PROCESS {
 
 }
 
-function Add-CloudEventXmlData {
+function Set-CloudEventXmlData {
 <#
    .SYNOPSIS
-   This function adds XML format data to a cloud event.
+   This function sets XML format data into a cloud event.
 
    .DESCRIPTION
-   This function converts a PowerShell hashtable to XML format data and adds it to a cloud event.
+   This function converts a PowerShell hashtable to XML format data and sets it into a cloud event.
 
    .PARAMETER CloudEvent
-   Specifies the cloud event object to add data to.
+   Specifies the cloud event object to set data into.
 
    .PARAMETER Data
-   Specifies the PowerShell hashtable object that is added as XML to the cloud event 'data' attribute.
+   Specifies the PowerShell hashtable object that is set as XML on the cloud event 'data' attribute.
    The 'datacontenttype' attribute is set to 'applicaiton/xml'
 
    .PARAMETER AttributesKeysInElementAttributes
@@ -219,9 +219,9 @@ function Add-CloudEventXmlData {
 
    .EXAMPLE
    $cloudEvent = New-CloudEvent -Type 'com.example.object.deleted.v2' -Source 'mailto:cncf-wg-serverless@lists.cncf.io' -Id '6e8bc430-9c3a-11d9-9669-0800200c9a66' -Time (Get-Date)
-   $cloudEvent | Add-CloudEventXmlData -Data @{ 'key1' = 'value1'; 'key2' = 'value2'; } -AttributesKeysInElementAttributes $true
+   $cloudEvent | Set-CloudEventXmlData -Data @{ 'key1' = 'value1'; 'key2' = 'value2'; } -AttributesKeysInElementAttributes $true
 
-   Adds XML data to the cloud event
+   Sets XML data into the cloud event
 #>
 
 [CmdletBinding()]
@@ -256,7 +256,7 @@ PROCESS {
 }
 
 }
-#endregion Add Data Functions
+#endregion Set Data Functions
 
 #region Read Data Functions
 function Read-CloudEventData {

--- a/src/CloudEventsPowerShell/CloudEvents.Sdk.psm1
+++ b/src/CloudEventsPowerShell/CloudEvents.Sdk.psm1
@@ -76,13 +76,13 @@ PROCESS {
 function Set-CloudEventData {
 <#
    .SYNOPSIS
-   This function sets data into a cloud event.
+   This function sets data in a cloud event.
 
    .DESCRIPTION
-   This function sets data into a cloud event object with the provided parameters.
+   This function sets data in a cloud event object with the provided parameters.
 
    .PARAMETER CloudEvent
-   Specifies the cloud event object to set data into.
+   Specifies the cloud event object to set data to.
 
    .PARAMETER Data
    Specifies the data object that is set to the cloud event 'data' attribute.
@@ -95,7 +95,7 @@ function Set-CloudEventData {
    $cloudEvent = New-CloudEvent -Type 'com.example.object.deleted.v2' -Source 'mailto:cncf-wg-serverless@lists.cncf.io' -Id '6e8bc430-9c3a-11d9-9669-0800200c9a66' -Time (Get-Date)
    $cloudEvent | Set-CloudEventData -Data '<much wow="xml"/>' -DataContentType 'application/xml'
 
-   Sets xml data into the cloud event
+   Sets xml data to the cloud event
 #>
 
 [CmdletBinding()]
@@ -138,24 +138,29 @@ PROCESS {
 function Set-CloudEventJsonData {
 <#
    .SYNOPSIS
-   This function sets JSON format data into a cloud event.
+   This function sets JSON format data in a cloud event.
 
    .DESCRIPTION
-   This function converts a PowerShell hashtable to JSON format data and sets it into a cloud event.
+   This function converts a PowerShell hashtable to JSON format data and sets it in a cloud event.
 
    .PARAMETER CloudEvent
-   Specifies the cloud event object to set data into.
+   Specifies the cloud event object to set data in.
 
    .PARAMETER Data
    Specifies the PowerShell hashtable object that is set as JSON on the cloud event 'data' attribute.
-   The 'datacontenttype' attribute is set to 'applicaiton/json'
+   The 'datacontenttype' attribute is set to 'application/json'
+
+   .PARAMETER Depth
+   The maximum depth of the input hashtable specified on the `Data` parameter that will be converted to JSON.
+   This parameter is passed on the `-Depth` parameter of the `ConvertTo-Json` cmdlet.
+   The default value is 3
 
 
    .EXAMPLE
    $cloudEvent = New-CloudEvent -Type 'com.example.object.deleted.v2' -Source 'mailto:cncf-wg-serverless@lists.cncf.io' -Id '6e8bc430-9c3a-11d9-9669-0800200c9a66' -Time (Get-Date)
    $cloudEvent | Set-CloudEventJsonData -Data @{ 'key1' = 'value1'; 'key2' = 'value2'; }
 
-   Sets JSON data into the cloud event
+   Sets JSON data to the cloud event
 #>
 
 [CmdletBinding()]
@@ -196,17 +201,17 @@ PROCESS {
 function Set-CloudEventXmlData {
 <#
    .SYNOPSIS
-   This function sets XML format data into a cloud event.
+   This function sets XML format data in a cloud event.
 
    .DESCRIPTION
-   This function converts a PowerShell hashtable to XML format data and sets it into a cloud event.
+   This function converts a PowerShell hashtable to XML format data and sets it in a cloud event.
 
    .PARAMETER CloudEvent
-   Specifies the cloud event object to set data into.
+   Specifies the cloud event object to set data to.
 
    .PARAMETER Data
    Specifies the PowerShell hashtable object that is set as XML on the cloud event 'data' attribute.
-   The 'datacontenttype' attribute is set to 'applicaiton/xml'
+   The 'datacontenttype' attribute is set to 'application/xml'
 
    .PARAMETER AttributesKeysInElementAttributes
    Specifies how to format the XML. If specified and the input Data hashtable has pairs of 'Attributes', 'Value' keys
@@ -221,7 +226,7 @@ function Set-CloudEventXmlData {
    $cloudEvent = New-CloudEvent -Type 'com.example.object.deleted.v2' -Source 'mailto:cncf-wg-serverless@lists.cncf.io' -Id '6e8bc430-9c3a-11d9-9669-0800200c9a66' -Time (Get-Date)
    $cloudEvent | Set-CloudEventXmlData -Data @{ 'key1' = 'value1'; 'key2' = 'value2'; } -AttributesKeysInElementAttributes $true
 
-   Sets XML data into the cloud event
+   Sets XML data in the cloud event
 #>
 
 [CmdletBinding()]

--- a/src/CloudEventsPowerShell/CloudEvents.Sdk.psm1
+++ b/src/CloudEventsPowerShell/CloudEvents.Sdk.psm1
@@ -82,10 +82,10 @@ function Set-CloudEventData {
    This function sets data in a cloud event object with the provided parameters.
 
    .PARAMETER CloudEvent
-   Specifies the cloud event object to set data to.
+   Specifies the cloud event object that receives the data.
 
    .PARAMETER Data
-   Specifies the data object that is set to the cloud event 'data' attribute.
+   Specifies the data object for the cloud event 'data' attribute.
 
    .PARAMETER DataContentType
    Specifies the 'datacontenttype' attribute of the cloud event.
@@ -144,7 +144,7 @@ function Set-CloudEventJsonData {
    This function converts a PowerShell hashtable to JSON format data and sets it in a cloud event.
 
    .PARAMETER CloudEvent
-   Specifies the cloud event object to set data in.
+   Specifies the cloud event object that receives the data.
 
    .PARAMETER Data
    Specifies the PowerShell hashtable object that is set as JSON on the cloud event 'data' attribute.
@@ -207,7 +207,7 @@ function Set-CloudEventXmlData {
    This function converts a PowerShell hashtable to XML format data and sets it in a cloud event.
 
    .PARAMETER CloudEvent
-   Specifies the cloud event object to set data to.
+   Specifies the cloud event object that receives the data.
 
    .PARAMETER Data
    Specifies the PowerShell hashtable object that is set as XML on the cloud event 'data' attribute.

--- a/test/integration/HttpIntegration.Tests.ps1
+++ b/test/integration/HttpIntegration.Tests.ps1
@@ -58,7 +58,7 @@ Describe "Client-Server Integration Tests" {
                   -Source $script:ClientSource `
                   -Id 'integration-test-1' `
                   -Time (Get-Date) | `
-               Add-CloudEventJsonData -Data @{
+               Set-CloudEventJsonData -Data @{
                   'a1' = 'b'
                   'a2' = 'c'
                   'a3' = 'd'
@@ -106,7 +106,7 @@ Describe "Client-Server Integration Tests" {
                   -Source $script:ClientSource `
                   -Id 'integration-test-2' `
                   -Time (Get-Date) | `
-               Add-CloudEventXmlData -Data @{
+               Set-CloudEventXmlData -Data @{
                   'a1' = @{
                      'a2' = 'c'
                      'a3' = 'd'
@@ -157,7 +157,7 @@ Describe "Client-Server Integration Tests" {
                   -Source $script:ClientSource `
                   -Id 'integration-test-3' `
                   -Time (Get-Date) | `
-               Add-CloudEventJsonData -Data @{
+               Set-CloudEventJsonData -Data @{
                   'b1' = 'd'
                   'b2' = 'e'
                   'b3' = 'f'
@@ -205,7 +205,7 @@ Describe "Client-Server Integration Tests" {
                   -Source $script:ClientSource `
                   -Id 'integration-test-4' `
                   -Time (Get-Date) | `
-               Add-CloudEventXmlData -Data @{
+               Set-CloudEventXmlData -Data @{
                   'b1' = @{
                      'b2' = 'e'
                      'b3' = 'f'
@@ -256,7 +256,7 @@ Describe "Client-Server Integration Tests" {
                   -Source $script:ClientSource `
                   -Id 'integration-test-5' `
                   -Time (Get-Date) | `
-               Add-CloudEventData `
+               Set-CloudEventData `
                   -Data 'This is text data' `
                   -DataContentType 'application/text'
 

--- a/test/integration/HttpServer.ps1
+++ b/test/integration/HttpServer.ps1
@@ -113,15 +113,15 @@ while ( -not $global:serverStopRequested ) {
          $requestCloudEventJsonData = $requestCloudEvent | Read-CloudEventJsonData
          $requestCloudEventXmlData = $requestCloudEvent | Read-CloudEventXmlData -ConvertMode 'SkipAttributes'
          if ($requestCloudEventJsonData) {
-            $cloudEvent = $cloudEvent | Add-CloudEventJsonData `
+            $cloudEvent = $cloudEvent | Set-CloudEventJsonData `
                -Data $requestCloudEventJsonData
          } elseif ($requestCloudEventXmlData) {
-            $cloudEvent = $cloudEvent | Add-CloudEventXmlData `
+            $cloudEvent = $cloudEvent | Set-CloudEventXmlData `
                -Data $requestCloudEventXmlData `
                -AttributesKeysInElementAttributes $false
          } else {
             $requestCloudEventData = $requestCloudEvent | Read-CloudEventData
-            $cloudEvent = $cloudEvent | Add-CloudEventData `
+            $cloudEvent = $cloudEvent | Set-CloudEventData `
                -Data $requestCloudEventData `
                -DataContentType $requestCloudEvent.DataContentType
          }

--- a/test/unit/ConvertTo-HttpMessage.Tests.ps1
+++ b/test/unit/ConvertTo-HttpMessage.Tests.ps1
@@ -26,7 +26,7 @@ Describe "ConvertTo-HttpMessage Function Tests" {
                         -Time $expectedTime
 
          $expectedData = @{ 'key1' = 'value2'; 'key3' = 'value4' }
-         $cloudEvent = Add-CloudEventJsonData `
+         $cloudEvent = Set-CloudEventJsonData `
                         -CloudEvent $cloudEvent `
                         -Data $expectedData
 
@@ -75,7 +75,7 @@ Describe "ConvertTo-HttpMessage Function Tests" {
                         -Source $expectedSource
 
          $expectedData = '<much wow="xml"/>'
-         $cloudEvent = Add-CloudEventData `
+         $cloudEvent = Set-CloudEventData `
                         -CloudEvent $cloudEvent `
                         -Data $expectedData `
                         -DataContentType $expectedDataContentType
@@ -120,7 +120,7 @@ Describe "ConvertTo-HttpMessage Function Tests" {
                         -Time $expectedTime
 
          $expectedData = @{ 'key1' = 'value2'; 'key3' = 'value4' }
-         $cloudEvent = Add-CloudEventJsonData `
+         $cloudEvent = Set-CloudEventJsonData `
                         -CloudEvent $cloudEvent `
                         -Data $expectedData
 
@@ -185,7 +185,7 @@ Describe "ConvertTo-HttpMessage Function Tests" {
                         -Source $expectedSource
 
          $expectedData = '<much wow="xml"/>'
-         $cloudEvent = Add-CloudEventData `
+         $cloudEvent = Set-CloudEventData `
                         -CloudEvent $cloudEvent `
                         -Data $expectedData `
                         -DataContentType $expectedDataContentType

--- a/test/unit/Read-CloudEventData.Tests.ps1
+++ b/test/unit/Read-CloudEventData.Tests.ps1
@@ -16,7 +16,7 @@ Describe "Read-CloudEventData Function Tests" {
          $expectedData = '<much wow="xml"/>'
          $expectedDataContentType = 'text/xml'
 
-         $cloudEvent = $cloudEvent | Add-CloudEventData -Data $expectedData -DataContentType $expectedDataContentType
+         $cloudEvent = $cloudEvent | Set-CloudEventData -Data $expectedData -DataContentType $expectedDataContentType
 
          # Act
          $actual = $cloudEvent | Read-CloudEventData

--- a/test/unit/Read-CloudEventJsonData.Tests.ps1
+++ b/test/unit/Read-CloudEventJsonData.Tests.ps1
@@ -14,7 +14,7 @@ Describe "Read-CloudEventJsonData Function Tests" {
 
          $expectedHtData = @{'a' = 'b'}
 
-         $cloudEvent = $cloudEvent | Add-CloudEventJsonData -Data $expectedHtData
+         $cloudEvent = $cloudEvent | Set-CloudEventJsonData -Data $expectedHtData
 
          # Act
          $actual = $cloudEvent | Read-CloudEventJsonData
@@ -32,7 +32,7 @@ Describe "Read-CloudEventJsonData Function Tests" {
                         -Type test `
                         -Source 'urn:test'
 
-         $cloudEvent = $cloudEvent | Add-CloudEventData -Data "test" -DataContentType 'application/text'
+         $cloudEvent = $cloudEvent | Set-CloudEventData -Data "test" -DataContentType 'application/text'
          $pre
 
          # Act
@@ -58,7 +58,7 @@ Describe "Read-CloudEventJsonData Function Tests" {
             }
          }
 
-         $cloudEvent = $cloudEvent | Add-CloudEventJsonData -Data $expectedHtData -Depth 4
+         $cloudEvent = $cloudEvent | Set-CloudEventJsonData -Data $expectedHtData -Depth 4
 
          # Act
          $actual = $cloudEvent | Read-CloudEventJsonData -Depth 4

--- a/test/unit/Read-CloudEventJsonData.Tests.ps1
+++ b/test/unit/Read-CloudEventJsonData.Tests.ps1
@@ -14,7 +14,7 @@ Describe "Read-CloudEventJsonData Function Tests" {
 
          $expectedHtData = @{'a' = 'b'}
 
-         $cloudEvent = $cloudEvent | Set-CloudEventJsonData -Data $expectedHtData
+         $cloudEvent = $cloudEvent | Set-CloudEventJsonData -Data $expectedHtData -Depth 1
 
          # Act
          $actual = $cloudEvent | Read-CloudEventJsonData

--- a/test/unit/Read-CloudEventXmlData.Tests.ps1
+++ b/test/unit/Read-CloudEventXmlData.Tests.ps1
@@ -15,7 +15,7 @@ Describe "Read-CloudEventXmlData Function Tests" {
          $xmlData = "<a>b</a>"
          $expectedHtData = @{'a' = 'b'}
 
-         $cloudEvent = $cloudEvent | Add-CloudEventData -Data $xmlData -DataContentType 'application/xml'
+         $cloudEvent = $cloudEvent | Set-CloudEventData -Data $xmlData -DataContentType 'application/xml'
 
          # Act
          $actual = $cloudEvent | Read-CloudEventXmlData -ConvertMode 'SkipAttributes'
@@ -33,7 +33,7 @@ Describe "Read-CloudEventXmlData Function Tests" {
                         -Type test `
                         -Source 'urn:test'
 
-         $cloudEvent = $cloudEvent | Add-CloudEventData -Data "test" -DataContentType 'application/text'
+         $cloudEvent = $cloudEvent | Set-CloudEventData -Data "test" -DataContentType 'application/text'
          $pre
 
          # Act
@@ -60,7 +60,7 @@ Describe "Read-CloudEventXmlData Function Tests" {
             }
          }
 
-         $cloudEvent = $cloudEvent | Add-CloudEventData -Data $xmlData -DataContentType 'application/xml'
+         $cloudEvent = $cloudEvent | Set-CloudEventData -Data $xmlData -DataContentType 'application/xml'
 
          # Act
          $actual = $cloudEvent | Read-CloudEventXmlData -ConvertMode 'SkipAttributes'

--- a/test/unit/Set-CloudEventData.Tests.ps1
+++ b/test/unit/Set-CloudEventData.Tests.ps1
@@ -3,9 +3,9 @@
 #  SPDX-License-Identifier: Apache-2.0
 # **************************************************************************
 
-Describe "Add-CloudEventData Function Tests" {
-   Context "Adds Data" {
-      It 'Adds byte[] data' {
+Describe "Set-CloudEventData Function Tests" {
+   Context "Sets Data" {
+      It 'Sets byte[] data' {
          # Arrange
          $cloudEvent = New-CloudEvent `
                         -Id ([Guid]::NewGuid()) `
@@ -18,7 +18,7 @@ Describe "Add-CloudEventData Function Tests" {
 
          # Act
          $actual = $cloudEvent | `
-            Add-CloudEventData `
+            Set-CloudEventData `
                -Data $expectedData `
                -DataContentType $expectedDataContentType
 
@@ -28,7 +28,7 @@ Describe "Add-CloudEventData Function Tests" {
          $actual.Data | Should -Be $expectedData
       }
 
-      It 'Adds xml text data' {
+      It 'Sets xml text data' {
          # Arrange
          $cloudEvent = New-CloudEvent `
                         -Id ([Guid]::NewGuid()) `
@@ -41,7 +41,7 @@ Describe "Add-CloudEventData Function Tests" {
 
          # Act
          $actual = $cloudEvent | `
-            Add-CloudEventData `
+            Set-CloudEventData `
                -Data $expectedData `
                -DataContentType $expectedDataContentType
 
@@ -64,7 +64,7 @@ Describe "Add-CloudEventData Function Tests" {
                         -Source 'urn:test'
 
          # Act & Assert
-         { Add-CloudEventData `
+         { Set-CloudEventData `
                -CloudEvent $cloudEvent `
                -Data '1' `
                -DataContentType $invalidContentType } | `
@@ -81,7 +81,7 @@ Describe "Add-CloudEventData Function Tests" {
                         -Source 'urn:test'
 
          # Act & Assert
-         { Add-CloudEventData `
+         { Set-CloudEventData `
                -CloudEvent $cloudEvent `
                -Data '1' `
                -DataContentType $invalidContentType } | `
@@ -98,7 +98,7 @@ Describe "Add-CloudEventData Function Tests" {
                         -Source 'urn:test'
 
          # Act & Assert
-         { Add-CloudEventData `
+         { Set-CloudEventData `
                -CloudEvent $cloudEvent `
                -Data '1' `
                -DataContentType $invalidContentType } | `

--- a/test/unit/Set-CloudEventJsonData.Tests.ps1
+++ b/test/unit/Set-CloudEventJsonData.Tests.ps1
@@ -3,9 +3,9 @@
 #  SPDX-License-Identifier: Apache-2.0
 # **************************************************************************
 
-Describe "Add-CloudEventJsonData Function Tests" {
-   Context "Adds Json Data" {
-      It 'Adds json data with depth 1' {
+Describe "Set-CloudEventJsonData Function Tests" {
+   Context "Sets Json Data" {
+      It 'Sets json data with depth 1' {
          # Arrange
          $cloudEvent = New-CloudEvent `
                         -Id ([Guid]::NewGuid()) `
@@ -19,7 +19,7 @@ Describe "Add-CloudEventJsonData Function Tests" {
          $htData = @{'a' = 'b'}
 
          # Act
-         $actual = $cloudEvent | Add-CloudEventJsonData -Data $htData
+         $actual = $cloudEvent | Set-CloudEventJsonData -Data $htData
 
          # Assert
          $actual | Should -Not -Be $null
@@ -27,7 +27,7 @@ Describe "Add-CloudEventJsonData Function Tests" {
          $actual.Data | Should -Be $expectedJson
       }
 
-      It 'Adds json data with depth 4' {
+      It 'Sets json data with depth 4' {
          # Arrange
          $cloudEvent = New-CloudEvent `
                         -Id ([Guid]::NewGuid()) `
@@ -55,7 +55,7 @@ Describe "Add-CloudEventJsonData Function Tests" {
          }
 
          # Act
-         $actual = $cloudEvent | Add-CloudEventJsonData -Data $htData -Depth 4
+         $actual = $cloudEvent | Set-CloudEventJsonData -Data $htData -Depth 4
 
          # Assert
          $actual | Should -Not -Be $null

--- a/test/unit/Set-CloudEventJsonData.Tests.ps1
+++ b/test/unit/Set-CloudEventJsonData.Tests.ps1
@@ -19,7 +19,7 @@ Describe "Set-CloudEventJsonData Function Tests" {
          $htData = @{'a' = 'b'}
 
          # Act
-         $actual = $cloudEvent | Set-CloudEventJsonData -Data $htData
+         $actual = $cloudEvent | Set-CloudEventJsonData -Data $htData -Depth 1
 
          # Assert
          $actual | Should -Not -Be $null

--- a/test/unit/Set-CloudEventXmlData.Tests.ps1
+++ b/test/unit/Set-CloudEventXmlData.Tests.ps1
@@ -3,9 +3,9 @@
 #  SPDX-License-Identifier: Apache-2.0
 # **************************************************************************
 
-Describe "Add-CloudEventXmlData Function Tests" {
-   Context "Adds Xml Data" {
-      It 'Adds xml data with depth 1' {
+Describe "Set-CloudEventXmlData Function Tests" {
+   Context "Sets Xml Data" {
+      It 'Sets xml data with depth 1' {
          # Arrange
          $cloudEvent = New-CloudEvent `
                         -Id ([Guid]::NewGuid()) `
@@ -17,7 +17,7 @@ Describe "Add-CloudEventXmlData Function Tests" {
          $htData = @{'a' = 'b'}
 
          # Act
-         $actual = $cloudEvent | Add-CloudEventXmlData -Data $htData -AttributesKeysInElementAttributes $false
+         $actual = $cloudEvent | Set-CloudEventXmlData -Data $htData -AttributesKeysInElementAttributes $false
 
          # Assert
          $actual | Should -Not -Be $null
@@ -25,7 +25,7 @@ Describe "Add-CloudEventXmlData Function Tests" {
          $actual.Data | Should -Be $expectedXml
       }
 
-      It 'Adds xml data with depth 4' {
+      It 'Sets xml data with depth 4' {
          # Arrange
          $cloudEvent = New-CloudEvent `
                         -Id ([Guid]::NewGuid()) `
@@ -45,7 +45,7 @@ Describe "Add-CloudEventXmlData Function Tests" {
          }
 
          # Act
-         $actual = $cloudEvent | Add-CloudEventXmlData -Data $htData -AttributesKeysInElementAttributes $false
+         $actual = $cloudEvent | Set-CloudEventXmlData -Data $htData -AttributesKeysInElementAttributes $false
 
          # Assert
          $actual | Should -Not -Be $null
@@ -53,7 +53,7 @@ Describe "Add-CloudEventXmlData Function Tests" {
          $actual.Data | Should -Be $expectedXml
       }
 
-      It 'Should throw when no single root key hashtable is passed to the Add-CloudEventXmlData Data parameter' {
+      It 'Should throw when no single root key hashtable is passed to the Set-CloudEventXmlData Data parameter' {
          # Arrange
          $cloudEvent = New-CloudEvent `
                         -Id ([Guid]::NewGuid()) `
@@ -66,7 +66,7 @@ Describe "Add-CloudEventXmlData Function Tests" {
          }
 
          # Act & Assert
-         { $cloudEvent | Add-CloudEventXmlData -Data $htData -AttributesKeysInElementAttributes $false} | `
+         { $cloudEvent | Set-CloudEventXmlData -Data $htData -AttributesKeysInElementAttributes $false} | `
          Should -Throw '*Input Hashtable must have single root key*'
       }
    }


### PR DESCRIPTION
* Addresses issue #9 renaming `Add-CloudEvent*Data` functions to `Set-CloudEvent*Data`. As described in the issue the Add notion is not correct for the functions functionality. `Set` verb notion matches the behavior of the functions.
* Increment minor version of the module. The module is not yet released but this is a backward compatibility breaking change. 
* Remove module catalog file creation from build.ps1 because catalog file is needed only when module is signed. We still don't have a signing implementation for this module.
* Testing done:
```powershell
> .\build.ps1
[11:24:08 AM] INFO: Publish CloudEvents.Sdk Module to 'C:\git-repos\dmilov-forks\sdk-powershell\CloudEvents.Sdk'
Microsoft (R) Build Engine version 16.8.3+39993bd9d for .NET
Copyright (C) Microsoft Corporation. All rights reserved.
                                                                                                                    Determining projects to restore...                                                                                All projects are up-to-date for restore.                                                                          CloudEventsPowerShell -> C:\git-repos\dmilov-forks\sdk-powershell\src\CloudEventsPowerShell\bin\Release\netstandard2.0\CloudEventsPowerShell.dll
  CloudEventsPowerShell -> C:\git-repos\dmilov-forks\sdk-powershell\CloudEvents.Sdk\
[11:24:10 AM] INFO: Run unit tests

Starting discovery in 9 files.
Discovery finished in 342ms.
[+] C:\git-repos\dmilov-forks\sdk-powershell\test\unit\ConvertFrom-HttpMessage.Tests.ps1 1.42s (421ms|812ms)
[+] C:\git-repos\dmilov-forks\sdk-powershell\test\unit\ConvertTo-HttpMessage.Tests.ps1 698ms (219ms|462ms)
[+] C:\git-repos\dmilov-forks\sdk-powershell\test\unit\New-CloudEvent.Tests.ps1 380ms (29ms|340ms)
[+] C:\git-repos\dmilov-forks\sdk-powershell\test\unit\Read-CloudEventData.Tests.ps1 356ms (17ms|324ms)
[+] C:\git-repos\dmilov-forks\sdk-powershell\test\unit\Read-CloudEventJsonData.Tests.ps1 384ms (44ms|327ms)
[+] C:\git-repos\dmilov-forks\sdk-powershell\test\unit\Read-CloudEventXmlData.Tests.ps1 439ms (68ms|343ms)
[+] C:\git-repos\dmilov-forks\sdk-powershell\test\unit\Set-CloudEventData.Tests.ps1 542ms (66ms|460ms)
[+] C:\git-repos\dmilov-forks\sdk-powershell\test\unit\Set-CloudEventJsonData.Tests.ps1 361ms (21ms|328ms)
[+] C:\git-repos\dmilov-forks\sdk-powershell\test\unit\Set-CloudEventXmlData.Tests.ps1 385ms (55ms|316ms)
Tests completed in 5.02s
Tests Passed: 28, Failed: 0, Skipped: 0 NotRun: 0
[11:24:17 AM] INFO: Run integration tests

Starting discovery in 1 files.
Discovery finished in 217ms.
[+] C:\git-repos\dmilov-forks\sdk-powershell\test\integration\HttpIntegration.Tests.ps1 2.84s (1.89s|757ms)
Tests completed in 2.86s
Tests Passed: 5, Failed: 0, Skipped: 0 NotRun: 0
```