### PR TITLE
Enable process exit in build.ps1

### DIFF
--- a/test/RunTests.ps1
+++ b/test/RunTests.ps1
@@ -27,6 +27,7 @@ if ($TestsType -eq 'unit' -or $TestsType -eq 'all') {
 
    $pesterConfiguration.Run.Path = (Join-Path $PSScriptRoot 'unit')
    $pesterConfiguration.Run.Container = $pesterContainer
+   $pesterConfiguration.Run.Exit = $EnableProcessExit.IsPresent
 
    Invoke-Pester -Configuration $pesterConfiguration
 }
@@ -42,6 +43,7 @@ if ($TestsType -eq 'integration' -or $TestsType -eq 'all') {
 
    $pesterConfiguration.Run.Path = (Join-Path $PSScriptRoot 'integration')
    $pesterConfiguration.Run.Container = $pesterContainer
+   $pesterConfiguration.Run.Exit = $EnableProcessExit.IsPresent
 
    Invoke-Pester -Configuration $pesterConfiguration
 }


### PR DESCRIPTION
* Address issue #19 
* Add `ExiteProcess` switch parameter to `build.ps1` 
* Set exit code equal to number of failing tests
* Testing done:
```powershell
> pwsh --command "C:\git-repos\github\sdk-powershell\build.ps1 -ExitProcess"
......
Tests Passed: 27, Failed: 1, Skipped: 0 NotRun: 0
> $LASTEXITCODE
1
```
```powershell
> pwsh --command "C:\git-repos\github\sdk-powershell\build.ps1 -ExitProcess"
......
Tests Passed: 28, Failed: 0, Skipped: 0 NotRun: 0
> $LASTEXITCODE
0
```
Signed-off-by: Dimitar Milov <dmilov@vmware.com>