### PR TITLE
Add stale action

### DIFF
--- a/.github/workflows/ps-sdk-stale.yaml
+++ b/.github/workflows/ps-sdk-stale.yaml
@@ -1,0 +1,36 @@
+# **************************************************************************
+#  Copyright (c) Cloud Native Foundation.
+#  SPDX-License-Identifier: Apache-2.0
+# **************************************************************************
+
+name: Close Stale
+
+on:
+  schedule:
+    - cron: "0 1 * * *" # daily
+
+jobs:
+  stale:
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: "actions/stale@v3"
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+
+          stale-issue-message: |-
+            This issue is stale because it has been open for 90 days with no
+            activity. It will automatically close after 30 more days of
+            inactivity. Mark as fresh by adding the comment `/remove-lifecycle stale`.
+          stale-issue-label: "lifecycle/stale"
+          exempt-issue-labels: "lifecycle/frozen"
+
+          stale-pr-message: |-
+            This Pull Request is stale because it has been open for 90 days with
+            no activity. It will automatically close after 30 more days of
+            inactivity. Mark as fresh by adding the comment `/remove-lifecycle stale`.
+          stale-pr-label: "lifecycle/stale"
+          exempt-pr-labels: "lifecycle/frozen"
+
+          days-before-stale: 90
+          days-before-close: 30


### PR DESCRIPTION
Warn and close stale issues/PRs after 30/90 days of inactivity. Runs nightly.

Closes: #7
Signed-off-by: Michael Gasch <mgasch@vmware.com>