### PR TITLE
Implement publish script

### DIFF
--- a/.github/workflows/ps-ce-sdk-release.yaml
+++ b/.github/workflows/ps-ce-sdk-release.yaml
@@ -1,0 +1,88 @@
+# **************************************************************************
+#  Copyright (c) Cloud Native Foundation.
+#  SPDX-License-Identifier: Apache-2.0
+# **************************************************************************
+
+name: Release
+
+on:
+  create:
+    tags:
+      - v*
+  workflow_dispatch:
+
+jobs:
+  psgallery-publish:
+    name: Release CloudEvents.Sdk Module
+    runs-on: "ubuntu-latest"
+    env:
+      OUTPUT_DIR: release
+      CHANGE_LOG_FILE_NAME: RELEASE_CHANGELOG.md
+
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Build and Test
+        shell: pwsh
+        run: ./build.ps1 -OutputDir $env:OUTPUT_DIR -TestsType all -ExitProcess
+
+      - name: Publish to PSGallery
+        shell: pwsh
+        run: ./publish.ps1 -ModuleReleaseDir $env:OUTPUT_DIR -NuGetApiKey ${{ secrets.CLOUDEVENTS_SDK_PUBLISHER_API_KEY }}
+
+      - name: Create CHANGELOG
+        env:
+          IMAGE: quay.io/git-chglog/git-chglog
+          # https://quay.io/repository/git-chglog/git-chglog from tag v0.14.2
+          IMAGE_SHA: 998e89dab8dd8284cfff5f8cfb9e9af41fe3fcd4671f2e86a180e453c20959e3
+        run: |
+          # generate CHANGELOG for this Github release tag only
+          docker run --rm -v $PWD:/workdir ${IMAGE}@sha256:${IMAGE_SHA} -o ${CHANGE_LOG_FILE_NAME} $(basename "${{ github.ref }}" )
+
+      - name: Create Github Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create $(basename "${{ github.ref }}") -F ${CHANGE_LOG_FILE_NAME}
+
+  changelog-pull-request:
+    needs: psgallery-publish
+    name: Create CHANGELOG PR
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      CHANGE_LOG_FILE_NAME: CHANGELOG.md
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          # for changelog
+          fetch-depth: 0
+          ref: "main"
+
+      - name: Create CHANGELOG commit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE: quay.io/git-chglog/git-chglog
+          # https://quay.io/repository/git-chglog/git-chglog from tag v0.14.2
+          IMAGE_SHA: 998e89dab8dd8284cfff5f8cfb9e9af41fe3fcd4671f2e86a180e453c20959e3
+        run: |
+          # update CHANGELOG.md
+          docker run --rm -v $PWD:/workdir ${IMAGE}@sha256:${IMAGE_SHA} -o ${CHANGE_LOG_FILE_NAME}
+
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "${{ github.actor }}"
+          git add ${CHANGE_LOG_FILE_NAME}
+          git commit -m "Update CHANGELOG for $(basename ${{ github.ref }})"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          delete-branch: true
+          title: "Update CHANGELOG"
+          body: |
+            Update CHANGELOG.md for new release
+

--- a/build.ps1
+++ b/build.ps1
@@ -42,7 +42,14 @@ $moduleName = 'CloudEvents.Sdk'
 
 #region Input
 if (-not $OutputDir) {
-   $OutputDir = $PSScriptRoot
+    $OutputDir = $PSScriptRoot
+}
+
+# Create Output Dir if it doesn't exist
+if (-not (Test-Path $OutputDir)) {
+    New-Item -ItemType Directory -Path $OutputDir -Force -Confirm:$false | Out-Null
+    # Get the full path
+    $OutputDir = (Resolve-Path $OutputDir).Path
 }
 
 $OutputDir = Join-Path $OutputDir $moduleName
@@ -112,7 +119,7 @@ Test-BuildToolsAreAvailable
 
 # 2. Publish CloudEvents Module
 Write-InfoLog "Publish CloudEvents.Sdk Module to '$OutputDir'"
-dotnet publish -c Release -o $OutputDir $dotnetProjectPath
+dotnet publish -c Release -o $OutputDir $dotnetProjectPath | Out-Null
 
 # 3. Cleanup Unnecessary Outputs
 Get-ChildItem "$dotnetProjectName*" -Path $OutputDir  | Remove-Item -Confirm:$false
@@ -131,4 +138,6 @@ if ($TestsType -eq 'integration' -or $TestsType -eq 'all') {
 # 6. Set exit code
 if ($ExitProcess.IsPresent) {
     exit $failedTests
+} else {
+    $failedTests
 }

--- a/publish.ps1
+++ b/publish.ps1
@@ -1,0 +1,47 @@
+# **************************************************************************
+#  Copyright (c) Cloud Native Foundation.
+#  SPDX-License-Identifier: Apache-2.0
+# **************************************************************************
+
+<#
+    .SYNOPSIS
+    Publish the CloudEvents.Sdk module to PSGallery
+
+    .PARAMETER NuGetApiKey
+    PowerShell Gallery API Key to be used to publish the module
+
+    .PARAMETER ModuleReleaseDir
+    Parent directory of the 'CloudEvents.Sdk' module that will be published
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]
+    $NuGetApiKey,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateScript({ Test-Path $_ })]
+    [string]
+    $ModuleReleaseDir
+)
+
+# Work with full path in case relative path is provided
+$ModuleReleaseDir = (Resolve-Path $ModuleReleaseDir).Path
+
+$moduleName = 'CloudEvents.Sdk'
+
+# Build is successful and all tests pass
+$env:PSModulePath += [IO.Path]::PathSeparator + $ModuleReleaseDir
+
+$localModule = Get-Module $moduleName -ListAvailable
+$psGalleryModule = Find-Module -Name $moduleName -Repository PSGallery
+
+# Throw an exception if module with the same version is availble on PSGallery
+if ( $null -ne $psGalleryModule -and `
+     $null -ne $localModule -and `
+     $psGalleryModule.Version -eq $localModule.Version ) {
+    throw "'$moduleName' module with version '$($localModule.Version)' is already available on PSGallery"
+}
+
+Write-Host "Performing operation: Publish-Module -Name $moduleName -RequiredVersion $($localModule.Version) -NuGetApiKey *** -Repository PSGallery -Confirm:`$false"
+Publish-Module -Name $moduleName -RequiredVersion $localModule.Version -NuGetApiKey $NuGetApiKey -Repository PSGallery -Confirm:$false -ErrorAction Stop


### PR DESCRIPTION
Signed-off-by: Dimitar Milov <dmilov@vmware.com>

Add publish job to run on version tag

Signed-off-by: Dimitar Milov <dmilov@vmware.com>

## Description

Implement a publishing script that
- builds
- test
- publishes to PSGallery if and only if all tests pass and the module version is higher than the available on the PSGallery

Add GHA to trigger the publish script on version tag

Closes: #32 

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [X ] Run publish.ps1 locally with bad NuGetAPIKey
```powershell
> .\publish.ps1 -NuGetApiKey BAD
[1:03:33 PM] INFO: Publish CloudEvents.Sdk Module to 'C:\git-repos\github\sdk-powershell\CloudEvents.Sdk\CloudEvents.Sdk'
[1:03:35 PM] INFO: Run unit tests

Starting discovery in 9 files.
Discovery finished in 344ms.
[+] C:\git-repos\github\sdk-powershell\test\unit\ConvertFrom-HttpMessage.Tests.ps1 1.1s (360ms|564ms)
[+] C:\git-repos\github\sdk-powershell\test\unit\ConvertTo-HttpMessage.Tests.ps1 396ms (153ms|204ms)
[+] C:\git-repos\github\sdk-powershell\test\unit\New-CloudEvent.Tests.ps1 192ms (27ms|151ms)
[+] C:\git-repos\github\sdk-powershell\test\unit\Read-CloudEventData.Tests.ps1 171ms (13ms|145ms)
[+] C:\git-repos\github\sdk-powershell\test\unit\Read-CloudEventJsonData.Tests.ps1 196ms (45ms|134ms)
[+] C:\git-repos\github\sdk-powershell\test\unit\Read-CloudEventXmlData.Tests.ps1 252ms (80ms|148ms)
[+] C:\git-repos\github\sdk-powershell\test\unit\Set-CloudEventData.Tests.ps1 236ms (56ms|160ms)
[+] C:\git-repos\github\sdk-powershell\test\unit\Set-CloudEventJsonData.Tests.ps1 186ms (20ms|157ms)
[+] C:\git-repos\github\sdk-powershell\test\unit\Set-CloudEventXmlData.Tests.ps1 210ms (64ms|136ms)
Tests completed in 2.99s
Tests Passed: 28, Failed: 0, Skipped: 0 NotRun: 0
[1:03:39 PM] INFO: Run integration tests

Starting discovery in 1 files.
Discovery finished in 196ms.
[+] C:\git-repos\github\sdk-powershell\test\integration\HttpIntegration.Tests.ps1 2.07s (1.4s|504ms)
Tests completed in 2.1s
Tests Passed: 5, Failed: 0, Skipped: 0 NotRun: 0
Performing operation: Publish-Module -Name CloudEvents.Sdk -RequiredVersion 0.2.1 -NuGetApiKey '...' -Repository PSGallery -Confirm:$false
Write-Error: C:\program files\powershell\7\Modules\PowerShellGet\PSModule.psm1:10990
 Line |
10990 |  …             Publish-PSArtifactUtility @PublishPSArtifactUtility_Param …
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      | Failed to publish module 'CloudEvents.Sdk': 'dotnet cli failed to nuget push Pushing
      | CloudEvents.Sdk.0.2.1.nupkg to 'https://www.powershellgallery.com/api/v2/package/'...   PUT
      | https://www.powershellgallery.com/api/v2/package/   Forbidden
      | https://www.powershellgallery.com/api/v2/package/ 1330ms error: Response status code does not
      | indicate success: 403 (The specified API key is invalid, has expired, or does not have permission to
      | access the specified package.).   Usage: dotnet nuget push [arguments] [options]  Arguments:   [root]
      | Specify the path to the package and your API key to push the package to the server.  Options:
      | -h|--help                      Show help information   --force-english-output         Forces the
      | application to run using an invariant, English-based culture.   -s|--source <source>
      | Package source (URL, UNC/folder path or package source name) to use. Defaults to DefaultPushSource if
      | specified in NuGet.Config.   -ss|--symbol-source <source>   Symbol server URL to use.   -t|--timeout
      | <timeout>         Timeout for pushing to a server in seconds. Defaults to 300 seconds (5 minutes).
      | -k|--api-key <apiKey>          The API key for the server.   -sk|--symbol-api-key <apiKey>  The API
      | key for the symbol server.   -d|--disable-buffering         Disable buffering when pushing to an
      | HTTP(S) server to decrease memory usage.   -n|--no-symbols                If a symbols package
      | exists, it will not be pushed to a symbols server.   --no-service-endpoint          Does not append
      | "api/v2/package" to the source URL.   --interactive                  Allow the command to block and
      | require manual action for operations like authentication.   --skip-duplicate               If a
      | package and version already exists, skip it and continue with the next package in the push, if any. '.
```


**Test Configuration**:
* Toolchain:
* SDK:
* (add more if needed)

## Checklist:

- [x] My code follows the contribution
  [guidelines](https://github.com/cloudevents/sdk-powershell/blob/main/CONTRIBUTING.md)
  of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules